### PR TITLE
Fix/either

### DIFF
--- a/Either/Module
+++ b/Either/Module
@@ -1,34 +1,31 @@
-let open
-    :   ∀(a : Type)
-      → ∀(b : Type)
-      → { Left  : ∀(Left : a) → ./Either a b
-        , Right : ∀(Right : b) → ./Either a b
-        , fold : ∀(c : Type) → (a → c) → (b → c) → ./Either a b → c
-        , fromRight : b → ./Either a b → b
-        , fromLeft : a → ./Either a b → a
-        , isRight : ./Either a b → Bool
-        , isLeft : ./Either a b → Bool
-        , partition : List (./Either a b) → { lefts : List a, rights : List b }
-        , mapRight : ∀(d : Type) → (b → d) → ./Either a b → ./Either a d
-        , mapLeft : ∀(c : Type) → (a → c) → ./Either a b → ./Either c b
-        , mapBoth : ∀(c : Type) → ∀(d : Type) → (a → c) → (b → d) → ./Either a b → ./Either c d
-        , rights : List (./Either a b) → List b
-        , lefts : List (./Either a b) → List a
-        }
-    =  λ(a : Type)
-     → λ(b : Type)
-     → { Left  = λ(Left : a) → < Left = Left | Right : b >
-       , Right = λ(Right : b) → < Right = Right | Left : a >
-       , fold = λ(c : Type) → λ(f : a → c) → λ(g : b → c) → λ(e : ./Either a b) → ./fold a b c f g e
-       , fromRight = λ(def : b) → λ(e : ./Either a b) → ./fromRight a b def e
-       , fromLeft = λ(def : a) → λ(e : ./Either a b) → ./fromLeft a b def e
-       , isRight = λ(e : ./Either a b) → ./isRight a b e
-       , isLeft = λ(e : ./Either a b) → ./isLeft a b e
-       , partition = λ(eithers : List (./Either  a b)) -> ./partition a b eithers
-       , mapRight = λ(d : Type) → λ(f : b → d) → λ(e : ./Either a b) → ./mapRight a b d f e
-       , mapLeft = λ(c : Type) → λ(f : a → c) → λ(e : ./Either a b) → ./mapLeft a b c f e
-       , mapBoth = λ(c : Type) → λ(d : Type) → λ(f : a → c) → λ(g : b → d) → λ(e : ./Either a b) → ./mapBoth a b c d f g e
-       , rights = λ(eithers : List (./Either a b)) → ./rights a b eithers
-       , lefts = λ(eithers : List (./Either a b)) → ./lefts a b eithers
-       }
-in open
+    let Either = ./Type
+
+in    λ(a : Type)
+    → λ(b : Type)
+    → { Left      = λ(Left : a) → < Left = Left | Right : b >
+      , Right     = λ(Right : b) → < Right = Right | Left : a >
+      , fold      =
+            λ(c : Type)
+          → λ(f : a → c)
+          → λ(g : b → c)
+          → λ(e : Either a b)
+          → ./fold  a b c f g e
+      , fromLeft  = λ(def : a) → λ(e : Either a b) → ./fromLeft  a b def e
+      , fromRight = λ(def : b) → λ(e : Either a b) → ./fromRight  a b def e
+      , isLeft    = λ(e : Either a b) → ./isLeft  a b e
+      , isRight   = λ(e : Either a b) → ./isRight  a b e
+      , lefts     = λ(eithers : List (Either a b)) → ./lefts  a b eithers
+      , mapBoth   =
+            λ(c : Type)
+          → λ(d : Type)
+          → λ(f : a → c)
+          → λ(g : b → d)
+          → λ(e : Either a b)
+          → ./mapBoth  a b c d f g e
+      , mapLeft   =
+          λ(c : Type) → λ(f : a → c) → λ(e : Either a b) → ./mapLeft  a b c f e
+      , mapRight  =
+          λ(d : Type) → λ(f : b → d) → λ(e : Either a b) → ./mapRight  a b d f e
+      , partition = λ(eithers : List (Either a b)) → ./partition  a b eithers
+      , rights    = λ(eithers : List (Either a b)) → ./rights  a b eithers
+      }

--- a/Either/Type
+++ b/Either/Type
@@ -1,6 +1,1 @@
-
-    let Either
-        : Type → Type → Type
-        = λ(a : Type) → λ(b : Type) → < Left : a | Right : b >
-
-in  Either
+λ(a : Type) → λ(b : Type) → < Left : a | Right : b >

--- a/Either/fold
+++ b/Either/fold
@@ -1,18 +1,9 @@
+    let Either = ./Type
 
-    let fold
-        :   ∀(a : Type)
-          → ∀(b : Type)
-          → ∀(c : Type)
-          → (a → c)
-          → (b → c)
-          → ./Either  a b
-          → c
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(c : Type)
-          → λ(f : a → c)
-          → λ(g : b → c)
-          → λ(e : ./Either  a b)
-          → let handlers = { Left = f, Right = g } in merge handlers e : c
-
-in  fold
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(c : Type)
+    → λ(f : a → c)
+    → λ(g : b → c)
+    → λ(e : Either a b)
+    → merge { Left = f, Right = g } e

--- a/Either/fromLeft
+++ b/Either/fromLeft
@@ -1,12 +1,7 @@
+    let Either = ./Type
 
-    let fromLeft
-        : ∀(a : Type) → ∀(b : Type) → a → ./Either  a b → a
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(def : a)
-          → λ(e : ./Either  a b)
-          →     let handlers = { Left = λ(x : a) → x, Right = λ(y : b) → def }
-
-            in  merge handlers e : a
-
-in  fromLeft
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(def : a)
+    → λ(e : Either a b)
+    → merge { Left = λ(x : a) → x, Right = λ(y : b) → def } e

--- a/Either/fromRight
+++ b/Either/fromRight
@@ -1,12 +1,7 @@
+    let Either = ./Type
 
-    let fromRight
-        : ∀(a : Type) → ∀(b : Type) → b → ./Either  a b → b
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(def : b)
-          → λ(e : ./Either  a b)
-          →     let handlers = { Left = λ(x : a) → def, Right = λ(y : b) → y }
-
-            in  merge handlers e : b
-
-in  fromRight
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(def : b)
+    → λ(e : Either a b)
+    → merge { Left = λ(x : a) → def, Right = λ(y : b) → y } e

--- a/Either/isLeft
+++ b/Either/isLeft
@@ -1,12 +1,6 @@
+    let Either = ./Type
 
-    let isLeft
-        : ∀(a : Type) → ∀(b : Type) → ./Either  a b → Bool
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(e : ./Either  a b)
-          →     let handlers =
-                      { Left = λ(x : a) → True, Right = λ(y : b) → False }
-
-            in  merge handlers e : Bool
-
-in  isLeft
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(e : Either a b)
+    → merge { Left = λ(x : a) → True, Right = λ(y : b) → False } e

--- a/Either/isRight
+++ b/Either/isRight
@@ -1,12 +1,6 @@
+    let Either = ./Type
 
-    let not =
-          https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/Bool/not 
+in  let not =
+          https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/Bool/not
 
-in  let isRight
-        : ∀(a : Type) → ∀(b : Type) → ./Either  a b → Bool
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(e : ./Either  a b)
-          → not (./isLeft  a b e)
-
-in  isRight
+in  λ(a : Type) → λ(b : Type) → λ(e : Either a b) → not (./isLeft  a b e)

--- a/Either/lefts
+++ b/Either/lefts
@@ -1,9 +1,6 @@
+    let Either = ./Type
 
-    let lefts
-        : ∀(a : Type) → ∀(b : Type) → List (./Either  a b) → List a
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(eithers : List (./Either  a b))
-          → (./partition  a b eithers).lefts
-
-in  lefts
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(eithers : List (Either a b))
+    → (./partition  a b eithers).lefts

--- a/Either/mapBoth
+++ b/Either/mapBoth
@@ -1,26 +1,14 @@
+    let Either = ./Type
 
-    let mapBoth
-        :   ∀(a : Type)
-          → ∀(b : Type)
-          → ∀(c : Type)
-          → ∀(d : Type)
-          → (a → c)
-          → (b → d)
-          → ./Either  a b
-          → ./Either  c d
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(c : Type)
-          → λ(d : Type)
-          → λ(f : a → c)
-          → λ(g : b → d)
-          → λ(e : ./Either  a b)
-          →     let handlers =
-                      { Left  = λ(x : a) → < Left = f x | Right : d >
-                      , Right = λ(y : b) → < Right = g y | Left : c >
-                      }
-            
-            in  merge handlers e : ./Either  c d
-
-in  mapBoth
-
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(c : Type)
+    → λ(d : Type)
+    → λ(f : a → c)
+    → λ(g : b → d)
+    → λ(e : Either a b)
+    → merge
+      { Left  = λ(x : a) → < Left = f x | Right : d >
+      , Right = λ(y : b) → < Right = g y | Left : c >
+      }
+      e

--- a/Either/mapLeft
+++ b/Either/mapLeft
@@ -1,17 +1,8 @@
+    let Either = ./Type
 
-    let mapLeft
-        :   ∀(a : Type)
-          → ∀(b : Type)
-          → ∀(c : Type)
-          → (a → c)
-          → ./Either  a b
-          → ./Either  c b
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(c : Type)
-          → λ(f : a → c)
-          → λ(e : ./Either  a b)
-          → ./mapBoth  a b c b f (λ(x : b) → x) e
-
-in  mapLeft
-
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(c : Type)
+    → λ(f : a → c)
+    → λ(e : Either a b)
+    → ./mapBoth  a b c b f (λ(x : b) → x) e

--- a/Either/mapRight
+++ b/Either/mapRight
@@ -1,16 +1,8 @@
+    let Either = ./Type
 
-    let mapRight
-        :   ∀(a : Type)
-          → ∀(b : Type)
-          → ∀(d : Type)
-          → (b → d)
-          → ./Either  a b
-          → ./Either  a d
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(d : Type)
-          → λ(f : b → d)
-          → λ(e : ./Either  a b)
-          → ./mapBoth  a b a d (λ(x : a) → x) f e
-
-in  mapRight
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(d : Type)
+    → λ(f : b → d)
+    → λ(e : Either a b)
+    → ./mapBoth  a b a d (λ(x : a) → x) f e

--- a/Either/partition
+++ b/Either/partition
@@ -1,14 +1,16 @@
-let foldr =
+    let Either = ./Type
+
+in  let foldr =
           https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/List/fold
 
 in  let partition
         :   ∀(a : Type)
           → ∀(b : Type)
-          → List (./Either  a b)
+          → List (Either a b)
           → { lefts : List a, rights : List b }
         =   λ(a : Type)
           → λ(b : Type)
-          → λ(eithers : List (./Either  a b))
+          → λ(eithers : List (Either a b))
           →     let left =
                         λ(acc : { lefts : List a, rights : List b })
                       → λ(x : a)
@@ -20,10 +22,10 @@ in  let partition
                       → { lefts = acc.lefts, rights = [ y ] # acc.rights }
 
             in  foldr
-                (./Either  a b)
+                (Either a b)
                 eithers
                 { lefts : List a, rights : List b }
-                (   λ(e : ./Either  a b)
+                (   λ(e : Either a b)
                   → λ(acc : { lefts : List a, rights : List b })
                   → ./fold
                     a

--- a/Either/rights
+++ b/Either/rights
@@ -1,9 +1,6 @@
+    let Either = ./Type
 
-    let rights
-        : ∀(a : Type) → ∀(b : Type) → List (./Either  a b) → List b
-        =   λ(a : Type)
-          → λ(b : Type)
-          → λ(eithers : List (./Either  a b))
-          → (./partition  a b eithers).rights
-
-in  rights
+in    λ(a : Type)
+    → λ(b : Type)
+    → λ(eithers : List (Either a b))
+    → (./partition  a b eithers).rights


### PR DESCRIPTION
* Fixed importing of Either
* Don't use `let/in` for naming top level functions. Files do that themselves.