### PR TITLE
Flatten Type Classes

### DIFF
--- a/Applicative/Type
+++ b/Applicative/Type
@@ -1,11 +1,12 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type 
 
 in  let Applicative
-        : (Type → Type) -> Type
-        =   λ(f : Type -> Type) ->
-            { ap   :
+        : (Type → Type) → Type
+        =   λ(f : Type → Type)
+          → { ap :
                 ∀(a : Type) → ∀(b : Type) → ∀(g : f (a → b)) → ∀(fa : f a) → f b
-            , pure : ∀(a : Type) → a → f a
+            , pure :
+                ∀(a : Type) → a → f a
             }
 
-in  λ(f : Type -> Type) -> { applicative : Applicative f, functor : Functor f }
+in  λ(f : Type → Type) → Functor f ⩓ Applicative f

--- a/Applicative/liftA2
+++ b/Applicative/liftA2
@@ -19,13 +19,13 @@ in  let liftA2
           → λ(fa : f a)
           → λ(fb : f b)
           →     let h =
-                      app.functor.map
+                      app.map
                       a
                       (b → c)
                       (λ(aVal : a) → λ(bVal : b) → g aVal bVal)
                       fa
 
-            in  app.applicative.ap b c h fb
+            in  app.ap b c h fb
 
 in  liftA2
 

--- a/Applicative/package.dhall
+++ b/Applicative/package.dhall
@@ -1,80 +1,17 @@
     let Applicative = ./Type
 
-in  let Module
-        :   ∀(f : Type → Type)
-          → ∀ ( applicative
-              : { applicative :
-                    { ap   :
-                          ∀(a : Type)
-                        → ∀(b : Type)
-                        → ∀(g : f (a → b))
-                        → ∀(fa : f a)
-                        → f b
-                    , pure : ∀(a : Type) → a → f a
-                    }
-                , functor     :
-                    { map :
-                          ∀(a : Type)
-                        → ∀(b : Type)
-                        → ∀(g : a → b)
-                        → ∀(fa : f a)
-                        → f b
-                    }
-                }
-              )
-          → { ap           :
-                ∀(a : Type) → ∀(b : Type) → ∀(g : f (a → b)) → ∀(fa : f a) → f b
-            , leftApConst  :
-                ∀(a : Type) → ∀(b : Type) → ∀(fa : f a) → ∀(fb : f b) → f a
-            , liftA2       :
-                  ∀(a : Type)
-                → ∀(b : Type)
-                → ∀(c : Type)
-                → ∀(g : a → b → c)
-                → ∀(fa : f a)
-                → ∀(fb : f b)
-                → f c
-            , map          :
-                ∀(a : Type) → ∀(b : Type) → ∀(g : a → b) → ∀(fa : f a) → f b
-            , pure         : ∀(a : Type) → a → f a
-            , rightApConst :
-                ∀(a : Type) → ∀(b : Type) → ∀(fa : f a) → ∀(fb : f b) → f b
-            }
-        =   λ(f : Type → Type)
-          → λ(applicative : Applicative  f)
-          → { ap           =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : f (a → b))
-                → λ(fa : f a)
-                → applicative.applicative.ap a b g fa
-            , leftApConst  =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : f a)
-                → λ(fb : f b)
-                → ./leftApConst  f applicative a b fa fb
-            , liftA2       =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(c : Type)
-                → λ(g : a → b → c)
-                → λ(fa : f a)
-                → λ(fb : f b)
-                → ./liftA2  f applicative a b c g fa fb
-            , map          =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : a → b)
-                → λ(fa : f a)
-                → applicative.functor.map a b g fa
-            , pure         = λ(a : Type) → applicative.applicative.pure a
-            , rightApConst =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : f a)
-                → λ(fb : f b)
-                → ./rightApConst  f applicative a b fa fb
-            }
-
-in  Module
+in    λ(f : Type → Type)
+    → λ(applicative : Applicative f)
+    → { ap =
+          applicative.ap
+      , leftApConst =
+          ./leftApConst f applicative
+      , liftA2 =
+          ./liftA2 f applicative
+      , map =
+          applicative.map
+      , pure =
+          applicative.pure
+      , rightApConst =
+          ./rightApConst f applicative
+      }

--- a/Applicative/rightApConst
+++ b/Applicative/rightApConst
@@ -1,25 +1,24 @@
     let Applicative = ./Type
 
-in  let leftConst = ../Functor/leftConst
+in  let leftConst = ./../Functor/leftConst
 
 in  let rightApConst
         :   ∀(f : Type → Type)
-          → ∀(app : Applicative  f)
+          → ∀(app : Applicative f)
           → ∀(a : Type)
           → ∀(b : Type)
           → f a
           → f b
           → f b
         =   λ(f : Type → Type)
-          → λ(app : Applicative  f)
+          → λ(app : Applicative f)
           → λ(a : Type)
           → λ(b : Type)
           → λ(fa : f a)
           → λ(fb : f b)
           →     let apConst =
-                      leftConst f app.functor (b → b) a (λ(x : b) → x) fa
-
-            in  app.applicative.ap b b apConst fb
+                      leftConst f app.{ map } (b → b) a (λ(x : b) → x) fa
+            
+            in  app.ap b b apConst fb
 
 in  rightApConst
-

--- a/Either/Applicative
+++ b/Either/Applicative
@@ -1,25 +1,22 @@
-    let Applicative = ./../Applicative/Type 
+    let Applicative = ./../Applicative/Type
 
-in  let Either = ./Type 
+in  let Either = ./Type
 
 in    λ(a : Type)
-    → (     ./Functor  a
-          ⫽ { pure =
-                λ(b : Type) → λ(x : b) → < Right = x | Left : a >
-            , ap =
-                  λ(b : Type)
-                → λ(c : Type)
-                → λ(g : Either a (b → c))
-                → λ(fa : Either a b)
-                → merge
-                  { Left =
-                      λ(l : a) → < Left = l | Right : c >
-                  , Right =
-                          let map = (./Functor  a).map
-                      
-                      in  λ(f : b → c) → map b c f fa
-                  }
-                  g
-            }
-        : Applicative (Either a)
-      )
+    →     ./Functor a
+        ∧ { pure =
+              λ(b : Type) → λ(x : b) → < Right = x | Left : a >
+          , ap =
+                λ(b : Type)
+              → λ(c : Type)
+              → λ(g : Either a (b → c))
+              → λ(fa : Either a b)
+              → merge
+                { Left =
+                    λ(l : a) → < Left = l | Right : c >
+                , Right =
+                    let map = (./Functor a).map in λ(f : b → c) → map b c f fa
+                }
+                g
+          }
+      : Applicative (Either a)

--- a/Either/Applicative
+++ b/Either/Applicative
@@ -1,28 +1,25 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type 
 
-in  let Either = ./Type
+in  let Either = ./Type 
 
 in    λ(a : Type)
-    → (   { functor =
-              ./Functor  a
-          , applicative =
-              { pure =
-                  λ(b : Type) → λ(x : b) → < Right = x | Left : a >
-              , ap =
-                    λ(b : Type)
-                  → λ(c : Type)
-                  → λ(g : Either a (b → c))
-                  → λ(fa : Either a b)
-                  → merge
-                    { Left =
-                        λ(l : a) → < Left = l | Right : c >
-                    , Right =
-                            let map = (./Functor  a).map
-
-                        in  λ(f : b → c) → map b c f fa
-                    }
-                    g
-              }
-          }
+    → (     ./Functor  a
+          ⫽ { pure =
+                λ(b : Type) → λ(x : b) → < Right = x | Left : a >
+            , ap =
+                  λ(b : Type)
+                → λ(c : Type)
+                → λ(g : Either a (b → c))
+                → λ(fa : Either a b)
+                → merge
+                  { Left =
+                      λ(l : a) → < Left = l | Right : c >
+                  , Right =
+                          let map = (./Functor  a).map
+                      
+                      in  λ(f : b → c) → map b c f fa
+                  }
+                  g
+            }
         : Applicative (Either a)
       )

--- a/Either/Monad
+++ b/Either/Monad
@@ -1,26 +1,23 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type 
 
-in  let Either = ./Type
+in  let Either = ./Type 
 
 in    λ(a : Type)
-    → (   { applicative =
-              ./Applicative  a
-          , monad =
-              { bind =
-                    λ(b : Type)
-                  → λ(c : Type)
-                  → λ(fa : Either a b)
-                  → λ(k : b → Either a c)
-                  →     let map = (./Functor  a).map
-
-                    in  merge
-                        { Left =
-                            λ(l : a) → < Left = l | Right : c >
-                        , Right =
-                            λ(e : Either a c) → e
-                        }
-                        (map b (Either a c) k fa)
-              }
-          }
+    → (     ./Applicative  a
+          ⫽ { bind =
+                  λ(b : Type)
+                → λ(c : Type)
+                → λ(fa : Either a b)
+                → λ(k : b → Either a c)
+                →     let map = (./Functor  a).map
+                  
+                  in  merge
+                      { Left =
+                          λ(l : a) → < Left = l | Right : c >
+                      , Right =
+                          λ(e : Either a c) → e
+                      }
+                      (map b (Either a c) k fa)
+            }
         : Monad (Either a)
       )

--- a/Either/Monad
+++ b/Either/Monad
@@ -1,23 +1,22 @@
-    let Monad = ./../Monad/Type 
+    let Monad = ./../Monad/Type
 
-in  let Either = ./Type 
+in  let Either = ./Type
 
 in    λ(a : Type)
-    → (     ./Applicative  a
-          ⫽ { bind =
-                  λ(b : Type)
-                → λ(c : Type)
-                → λ(fa : Either a b)
-                → λ(k : b → Either a c)
-                →     let map = (./Functor  a).map
-                  
-                  in  merge
-                      { Left =
-                          λ(l : a) → < Left = l | Right : c >
-                      , Right =
-                          λ(e : Either a c) → e
-                      }
-                      (map b (Either a c) k fa)
-            }
-        : Monad (Either a)
-      )
+    →     ./Applicative a
+        ∧ { bind =
+                λ(b : Type)
+              → λ(c : Type)
+              → λ(fa : Either a b)
+              → λ(k : b → Either a c)
+              →     let map = (./Functor a).map
+                
+                in  merge
+                    { Left =
+                        λ(l : a) → < Left = l | Right : c >
+                    , Right =
+                        λ(e : Either a c) → e
+                    }
+                    (map b (Either a c) k fa)
+          }
+      : Monad (Either a)

--- a/Either/Traversable
+++ b/Either/Traversable
@@ -1,16 +1,13 @@
-    let Traversable = ../Traversable/Type
+    let Traversable = ./../Traversable/Type
 
-in  let Applicative = ../Applicative/Type
+in  let Applicative = ./../Applicative/Type
 
 in  let Either = ./Type
 
 in    λ(a : Type)
-    → { foldable =
-          ./Foldable
-      , functor =
-          ./Functor
-      , traversable =
-          { traverse =
+    →     ./Foldable a
+        ∧ ./Functor a
+        ∧ { traverse =
                 λ(f : Type → Type)
               → λ(applicative : Applicative f)
               → λ(b : Type)
@@ -20,12 +17,10 @@ in    λ(a : Type)
               → merge
                 { Left =
                       λ(l : a)
-                    → applicative.applicative.pure
-                      (Either a c)
-                      < Left = l | Right : c >
+                    → applicative.pure (Either a c) < Left = l | Right : c >
                 , Right =
                       λ(r : b)
-                    → applicative.functor.map
+                    → applicative.map
                       c
                       (Either a c)
                       (λ(x : c) → < Right = x | Left : a >)
@@ -33,4 +28,4 @@ in    λ(a : Type)
                 }
                 ts
           }
-      }
+      : Traversable (Either a)

--- a/Either/package.dhall
+++ b/Either/package.dhall
@@ -2,30 +2,37 @@
 
 in    λ(a : Type)
     → λ(b : Type)
-    → { Left      = λ(Left : a) → < Left = Left | Right : b >
-      , Right     = λ(Right : b) → < Right = Right | Left : a >
-      , fold      =
-            λ(c : Type)
-          → λ(f : a → c)
-          → λ(g : b → c)
-          → λ(e : Either a b)
-          → ./fold  a b c f g e
-      , fromLeft  = λ(def : a) → λ(e : Either a b) → ./fromLeft  a b def e
-      , fromRight = λ(def : b) → λ(e : Either a b) → ./fromRight  a b def e
-      , isLeft    = λ(e : Either a b) → ./isLeft  a b e
-      , isRight   = λ(e : Either a b) → ./isRight  a b e
-      , lefts     = λ(eithers : List (Either a b)) → ./lefts  a b eithers
-      , mapBoth   =
-            λ(c : Type)
-          → λ(d : Type)
-          → λ(f : a → c)
-          → λ(g : b → d)
-          → λ(e : Either a b)
-          → ./mapBoth  a b c d f g e
-      , mapLeft   =
-          λ(c : Type) → λ(f : a → c) → λ(e : Either a b) → ./mapLeft  a b c f e
-      , mapRight  =
-          λ(d : Type) → λ(f : b → d) → λ(e : Either a b) → ./mapRight  a b d f e
-      , partition = λ(eithers : List (Either a b)) → ./partition  a b eithers
-      , rights    = λ(eithers : List (Either a b)) → ./rights  a b eithers
-      }
+    →   { Left =
+            λ(Left : a) → < Left = Left | Right : b >
+        , Right =
+            λ(Right : b) → < Right = Right | Left : a >
+        , fromLeft =
+            λ(def : a) → λ(e : Either a b) → ./fromLeft a b def e
+        , fromRight =
+            λ(def : b) → λ(e : Either a b) → ./fromRight a b def e
+        , isLeft =
+            λ(e : Either a b) → ./isLeft a b e
+        , isRight =
+            λ(e : Either a b) → ./isRight a b e
+        , lefts =
+            λ(eithers : List (Either a b)) → ./lefts a b eithers
+        , mapBoth =
+              λ(c : Type)
+            → λ(d : Type)
+            → λ(f : a → c)
+            → λ(g : b → d)
+            → λ(e : Either a b)
+            → ./mapBoth a b c d f g e
+        , mapLeft =
+            λ(c : Type) → λ(f : a → c) → λ(e : Either a b) → ./mapLeft a b c f e
+        , mapRight =
+              λ(d : Type)
+            → λ(f : b → d)
+            → λ(e : Either a b)
+            → ./mapRight a b d f e
+        , partition =
+            λ(eithers : List (Either a b)) → ./partition a b eithers
+        , rights =
+            λ(eithers : List (Either a b)) → ./rights a b eithers
+        }
+      ∧ ./Monad a ⫽ ./Traversable a

--- a/EitherT/Applicative
+++ b/EitherT/Applicative
@@ -1,35 +1,34 @@
-    let Applicative = ./../Applicative/Type 
+    let Applicative = ./../Applicative/Type
 
-in  let EitherT = ./Type 
+in  let EitherT = ./Type
 
-in  let Either = ./../Either/Type 
+in  let Either = ./../Either/Type
 
-in  let EitherA = ./../Either/Applicative 
+in  let EitherA = ./../Either/Applicative
 
-in  let liftA2 = ./../Applicative/liftA2 
+in  let liftA2 = ./../Applicative/liftA2
 
 in    λ(a : Type)
     → λ(m : Type → Type)
     → λ(applicative : Applicative m)
-    → (     ./Functor  a m { map = applicative.map }
-          ⫽ { ap =
-                  λ(b : Type)
-                → λ(c : Type)
-                → λ(g : EitherT a m (b → c))
-                → λ(fa : EitherT a m b)
-                → liftA2
-                  m
-                  applicative
-                  (Either a (b → c))
-                  (Either a b)
-                  (Either a c)
-                  ((EitherA a).ap b c)
-                  g
-                  fa
-            , pure =
-                  λ(b : Type)
-                → λ(x : b)
-                → applicative.pure (Either a b) < Right = x | Left : a >
-            }
-        : Applicative (EitherT a m)
-      )
+    →     ./Functor a m { map = applicative.map }
+        ∧ { ap =
+                λ(b : Type)
+              → λ(c : Type)
+              → λ(g : EitherT a m (b → c))
+              → λ(fa : EitherT a m b)
+              → liftA2
+                m
+                applicative
+                (Either a (b → c))
+                (Either a b)
+                (Either a c)
+                ((EitherA a).ap b c)
+                g
+                fa
+          , pure =
+                λ(b : Type)
+              → λ(x : b)
+              → applicative.pure (Either a b) < Right = x | Left : a >
+          }
+      : Applicative (EitherT a m)

--- a/EitherT/Applicative
+++ b/EitherT/Applicative
@@ -1,40 +1,35 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type 
 
-in  let EitherT = ./Type
+in  let EitherT = ./Type 
 
-in  let Either = ../Either/Type
+in  let Either = ./../Either/Type 
 
-in  let EitherA = ../Either/Applicative
+in  let EitherA = ./../Either/Applicative 
 
-in  let liftA2 = ../Applicative/liftA2
+in  let liftA2 = ./../Applicative/liftA2 
 
 in    λ(a : Type)
     → λ(m : Type → Type)
     → λ(applicative : Applicative m)
-    → (   { applicative =
-              { ap =
-                    λ(b : Type)
-                  → λ(c : Type)
-                  → λ(g : EitherT a m (b → c))
-                  → λ(fa : EitherT a m b)
-                  → liftA2
-                    m
-                    applicative
-                    (Either a (b → c))
-                    (Either a b)
-                    (Either a c)
-                    ((EitherA a).applicative.ap b c)
-                    g
-                    fa
-              , pure =
-                    λ(b : Type)
-                  → λ(x : b)
-                  → applicative.applicative.pure
-                    (Either a b)
-                    < Right = x | Left : a >
-              }
-          , functor =
-              ./Functor  a m applicative.functor
-          }
+    → (     ./Functor  a m { map = applicative.map }
+          ⫽ { ap =
+                  λ(b : Type)
+                → λ(c : Type)
+                → λ(g : EitherT a m (b → c))
+                → λ(fa : EitherT a m b)
+                → liftA2
+                  m
+                  applicative
+                  (Either a (b → c))
+                  (Either a b)
+                  (Either a c)
+                  ((EitherA a).ap b c)
+                  g
+                  fa
+            , pure =
+                  λ(b : Type)
+                → λ(x : b)
+                → applicative.pure (Either a b) < Right = x | Left : a >
+            }
         : Applicative (EitherT a m)
       )

--- a/EitherT/Functor
+++ b/EitherT/Functor
@@ -1,20 +1,19 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type
 
 in  let EitherT = ./Type
 
-in  let Either = ../Either/Type
+in  let Either = ./../Either/Type
 
-in  let EitherF = ../Either/Functor
+in  let EitherF = ./../Either/Functor
 
 in    λ(a : Type)
     → λ(m : Type → Type)
     → λ(functor : Functor m)
-    → (   { map =
-                λ(b : Type)
-              → λ(c : Type)
-              → λ(f : b → c)
-              → λ(fa : EitherT a m b)
-              → functor.map (Either a b) (Either a c) ((EitherF a).map b c f) fa
-          }
-        : Functor (EitherT a m)
-      )
+    →   { map =
+              λ(b : Type)
+            → λ(c : Type)
+            → λ(f : b → c)
+            → λ(fa : EitherT a m b)
+            → functor.map (Either a b) (Either a c) ((EitherF a).map b c f) fa
+        }
+      : Functor (EitherT a m)

--- a/EitherT/Monad
+++ b/EitherT/Monad
@@ -1,42 +1,40 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type 
 
-in  let EitherT = ./Type
+in  let EitherT = ./Type 
 
-in  let Either = ../Either/Type
+in  let Either = ./../Either/Type 
 
-in  let EitherM = ../Either/Monad
+in  let EitherM = ./../Either/Monad 
 
-in  let fold = ../Either/fold
+in  let fold = ./../Either/fold 
 
 in    λ(a : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
-    → (   { applicative =
-              ./Applicative  a m monad.applicative
-          , monad =
-              { bind =
-                    λ(b : Type)
-                  → λ(c : Type)
-                  → λ(fa : EitherT a m b)
-                  → λ(k : b → EitherT a m c)
-                  → monad.monad.bind
-                    (Either a b)
-                    (Either a c)
-                    fa
-                    (   λ(either : Either a b)
-                      → fold
-                        a
-                        b
-                        (EitherT a m c)
-                        (   λ(l : a)
-                          → monad.applicative.applicative.pure
-                            (Either a c)
-                            < Left = l | Right : c >
-                        )
-                        (λ(r : b) → k r)
-                        either
-                    )
-              }
-          }
+    → (     ./Applicative 
+            a
+            m
+            { map = monad.map, ap = monad.ap, pure = monad.pure }
+          ⫽ { bind =
+                  λ(b : Type)
+                → λ(c : Type)
+                → λ(fa : EitherT a m b)
+                → λ(k : b → EitherT a m c)
+                → monad.bind
+                  (Either a b)
+                  (Either a c)
+                  fa
+                  (   λ(either : Either a b)
+                    → fold
+                      a
+                      b
+                      (EitherT a m c)
+                      (   λ(l : a)
+                        → monad.pure (Either a c) < Left = l | Right : c >
+                      )
+                      (λ(r : b) → k r)
+                      either
+                  )
+            }
         : Monad (EitherT a m)
       )

--- a/EitherT/Monad
+++ b/EitherT/Monad
@@ -1,40 +1,37 @@
-    let Monad = ./../Monad/Type 
+    let Monad = ./../Monad/Type
 
-in  let EitherT = ./Type 
+in  let EitherT = ./Type
 
-in  let Either = ./../Either/Type 
+in  let Either = ./../Either/Type
 
-in  let EitherM = ./../Either/Monad 
-
-in  let fold = ./../Either/fold 
+in  let fold = ./../Either/fold
 
 in    λ(a : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
-    → (     ./Applicative 
-            a
-            m
-            { map = monad.map, ap = monad.ap, pure = monad.pure }
-          ⫽ { bind =
-                  λ(b : Type)
-                → λ(c : Type)
-                → λ(fa : EitherT a m b)
-                → λ(k : b → EitherT a m c)
-                → monad.bind
-                  (Either a b)
-                  (Either a c)
-                  fa
-                  (   λ(either : Either a b)
-                    → fold
-                      a
-                      b
-                      (EitherT a m c)
-                      (   λ(l : a)
-                        → monad.pure (Either a c) < Left = l | Right : c >
-                      )
-                      (λ(r : b) → k r)
-                      either
-                  )
-            }
-        : Monad (EitherT a m)
-      )
+    →     ./Applicative
+          a
+          m
+          { map = monad.map, ap = monad.ap, pure = monad.pure }
+        ∧ { bind =
+                λ(b : Type)
+              → λ(c : Type)
+              → λ(fa : EitherT a m b)
+              → λ(k : b → EitherT a m c)
+              → monad.bind
+                (Either a b)
+                (Either a c)
+                fa
+                (   λ(either : Either a b)
+                  → fold
+                    a
+                    b
+                    (EitherT a m c)
+                    (   λ(l : a)
+                      → monad.pure (Either a c) < Left = l | Right : c >
+                    )
+                    (λ(r : b) → k r)
+                    either
+                )
+          }
+      : Monad (EitherT a m)

--- a/EitherT/Transformer
+++ b/EitherT/Transformer
@@ -1,22 +1,17 @@
-    let Transformer = ../Transformer/Type
+    let Transformer = ./../Transformer/Type
 
 in  let EitherT = ./Type
 
-in  let Either = ../Either/Type
+in  let Either = ./../Either/Type
 
-in  let Monad = ../Monad/Type
+in  let Monad = ./../Monad/Type
 
 in    λ(a : Type)
-    → (   { lift =
-                λ(m : Type → Type)
-              → λ(monad : Monad m)
-              → λ(b : Type)
-              → λ(ma : m b)
-              → monad.applicative.functor.map
-                b
-                (Either a b)
-                (λ(r : b) → < Right = r | Left : a >)
-                ma
-          }
-        : Transformer (EitherT a)
-      )
+    →   { lift =
+              λ(m : Type → Type)
+            → λ(monad : Monad m)
+            → λ(b : Type)
+            → λ(ma : m b)
+            → monad.map b (Either a b) (λ(r : b) → < Right = r | Left : a >) ma
+        }
+      : Transformer (EitherT a)

--- a/EitherT/Type
+++ b/EitherT/Type
@@ -1,3 +1,3 @@
-    let Either = ../Either/Type
+    let Either = ./../Either/Type
 
 in  λ(a : Type) → λ(m : Type → Type) → λ(b : Type) → m (Either a b)

--- a/Foldable/foldMap
+++ b/Foldable/foldMap
@@ -1,6 +1,6 @@
-    let Foldable = ./Type 
+    let Foldable = ./Type
 
-in  let Monoid = ../Monoid/Type 
+in  let Monoid = ./../Monoid/Type
 
 in    λ(m : Type)
     → λ(monoid : Monoid m)
@@ -9,9 +9,4 @@ in    λ(m : Type)
     → λ(a : Type)
     → λ(f : a → m)
     → λ(ts : t a)
-    → foldable.fold
-      a
-      ts
-      m
-      (λ(x : a) → λ(y : m) → monoid.semigroup.op (f x) y)
-      monoid.unit
+    → foldable.fold a ts m (λ(x : a) → λ(y : m) → monoid.op (f x) y) monoid.unit

--- a/Functor/Type
+++ b/Functor/Type
@@ -1,6 +1,2 @@
-    let Functor
-        : (Type → Type) → Type
-        =   λ(f : Type → Type)
-          → { map : ∀(a : Type) → ∀(b : Type) → ∀(g : a → b) → ∀(fa : f a) → f b }
-
-in  Functor
+  λ(f : Type → Type)
+→ { map : ∀(a : Type) → ∀(b : Type) → ∀(g : a → b) → ∀(fa : f a) → f b }

--- a/Functor/fromTraversable
+++ b/Functor/fromTraversable
@@ -1,3 +1,3 @@
   λ(f : Type → Type)
-→ λ(t : ../Traversable/Type  f)
-→ { map = t.traversable.traverse ../Id/Type  ../Id/Applicative  } : ../Functor/Type f
+→ λ(t : ./../Traversable/Type f)
+→ { map = t.traverse ./../Id/Type ./../Id/Applicative } : ./../Functor/Type f

--- a/Functor/leftConst
+++ b/Functor/leftConst
@@ -1,19 +1,9 @@
     let Functor = ./Type
 
-in  let leftConst
-        :   ∀(f : Type → Type)
-          → ∀(functor : Functor  f)
-          → ∀(a : Type)
-          → ∀(b : Type)
-          → a
-          → f b
-          → f a
-        =   λ(f : Type → Type)
-          → λ(functor : Functor  f)
-          → λ(a : Type)
-          → λ(b : Type)
-          → λ(val : a)
-          → λ(fb : f b)
-          → functor.map b a (λ(bVal : b) → val) fb
-
-in  leftConst
+in    λ(f : Type → Type)
+    → λ(functor : Functor f)
+    → λ(a : Type)
+    → λ(b : Type)
+    → λ(val : a)
+    → λ(fb : f b)
+    → functor.map b a (λ(bVal : b) → val) fb

--- a/Functor/rightConst
+++ b/Functor/rightConst
@@ -1,19 +1,9 @@
     let Functor = ./Type
 
-in  let rightConst
-        :   ∀(f : Type → Type)
-          → ∀(functor : Functor  f)
-          → ∀(a : Type)
-          → ∀(b : Type)
-          → f a
-          → b
-          → f b
-        =   λ(f : Type → Type)
-          → λ(functor : Functor  f)
-          → λ(a : Type)
-          → λ(b : Type)
-          → λ(fa : f a)
-          → λ(val : b)
-          → functor.map a b (λ(aVal : a) → val) fa
-
-in  rightConst
+in    λ(f : Type → Type)
+    → λ(functor : Functor f)
+    → λ(a : Type)
+    → λ(b : Type)
+    → λ(fa : f a)
+    → λ(val : b)
+    → functor.map a b (λ(aVal : a) → val) fa

--- a/Functor/void
+++ b/Functor/void
@@ -1,15 +1,7 @@
     let Functor = ./Type
 
-in  let void
-        :   ∀(f : Type → Type)
-          → ∀(functor : Functor  f)
-          → ∀(a : Type)
-          → ∀(fa : f a)
-          → f {}
-        =   λ(f : Type → Type)
-          → λ(functor : Functor  f)
-          → λ(a : Type)
-          → λ(fa : f a)
-          → ./rightConst  f functor a {} fa {=}
-
-in  void
+in    λ(f : Type → Type)
+    → λ(functor : Functor f)
+    → λ(a : Type)
+    → λ(fa : f a)
+    → ./rightConst f functor a {} fa {=}

--- a/Id/Applicative
+++ b/Id/Applicative
@@ -1,10 +1,7 @@
-  { functor =
-      ./Functor 
-  , applicative =
-      { pure =
-          λ(a : Type) → λ(x : a) → x
-      , ap =
-          λ(a : Type) → λ(b : Type) → λ(f : a → b) → f
-      }
-  }
-: ../Applicative/Type  ./Type 
+    ./Functor
+  ∧ { pure =
+        λ(a : Type) → λ(x : a) → x
+    , ap =
+        λ(a : Type) → λ(b : Type) → λ(f : a → b) → f
+    }
+: ./../Applicative/Type ./Type

--- a/Id/Functor
+++ b/Id/Functor
@@ -1,2 +1,2 @@
   { map = λ(a : Type) → λ(b : Type) → λ(f : a → b) → f }
-: ../Functor/Type  ./Type 
+: ./../Functor/Type ./Type

--- a/Id/Monad
+++ b/Id/Monad
@@ -1,17 +1,11 @@
-    let Monad = ../Monad/Type 
+    let Monad = ./../Monad/Type
 
-in  let Id = ./Type 
-
-in  (   { applicative =
-            ./Applicative 
-        , monad =
-            { bind =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : Id a)
-                → λ(k : a → Id b)
-                → k fa
-            }
+in      ./Applicative
+      ∧ { bind =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(fa : ./Type a)
+            → λ(k : a → ./Type b)
+            → k fa
         }
-      : Monad Id
-    )
+    : Monad ./Type

--- a/List/Applicative
+++ b/List/Applicative
@@ -1,26 +1,22 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
-in  let fold = ./Foldable .fold
+in  let fold = (./Foldable).fold
 
-in  let map = ./Functor .map
+in  let map = (./Functor).map
 
-in  (   { functor =
-            ./Functor
-        , applicative =
-            { pure =
-                λ(a : Type) → λ(x : a) → [ x ]
-            , ap =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : List (a → b))
-                → λ(fa : List a)
-                → fold
-                  (a → b)
-                  g
-                  (List b)
-                  (λ(k : a → b) → λ(xs : List b) → map a b k fa # xs)
-                  ([] : List b)
-            }
+in      ./Functor
+      ∧ { pure =
+            λ(a : Type) → λ(x : a) → [ x ]
+        , ap =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(g : List (a → b))
+            → λ(fa : List a)
+            → fold
+              (a → b)
+              g
+              (List b)
+              (λ(k : a → b) → λ(xs : List b) → map a b k fa # xs)
+              ([] : List b)
         }
-      : Applicative List
-    )
+    : Applicative List

--- a/List/Foldable
+++ b/List/Foldable
@@ -1,3 +1,1 @@
-    let Foldable = ../Foldable/Type
-
-in  ({ fold = List/fold } : Foldable List)
+{ fold = List/fold } : ./../Foldable/Type List

--- a/List/Functor
+++ b/List/Functor
@@ -1,16 +1,15 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type
 
-in  (   { map =
-              λ(a : Type)
-            → λ(b : Type)
-            → λ(g : a → b)
-            → λ(list : List a)
-            → List/fold
-              a
-              list
-              (List b)
-              (λ(x : a) → λ(xs : List b) → [ g x ] # xs)
-              ([] : List b)
-        }
-      : Functor List
-    )
+in    { map =
+            λ(a : Type)
+          → λ(b : Type)
+          → λ(g : a → b)
+          → λ(list : List a)
+          → List/fold
+            a
+            list
+            (List b)
+            (λ(x : a) → λ(xs : List b) → [ g x ] # xs)
+            ([] : List b)
+      }
+    : Functor List

--- a/List/Monad
+++ b/List/Monad
@@ -1,18 +1,14 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let concatMap =
           https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/List/concatMap
 
-in  (   { applicative =
-            ./Applicative
-        , monad =
-            { bind =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : List a)
-                → λ(k : a → List b)
-                → concatMap a b k fa
-            }
+in      ./Applicative
+      ∧ { bind =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(fa : List a)
+            → λ(k : a → List b)
+            → concatMap a b k fa
         }
-      : Monad List
-    )
+    : Monad List

--- a/List/Monoid
+++ b/List/Monoid
@@ -1,4 +1,1 @@
-    let Monoid = ../Monoid/Type
-
-in    λ(a : Type)
-    → ({ unit = [] : List a, semigroup = ./Semigroup a } : Monoid (List a))
+λ(a : Type) → { unit = [] : List a } ∧ ./Semigroup a : ./../Monoid/Type (List a)

--- a/List/Semigroup
+++ b/List/Semigroup
@@ -1,5 +1,3 @@
-
-    let Semigroup = ../Semigroup/Type
-
-in    λ(a : Type)
-    → ({ op = λ(xs : List a) → λ(ys : List a) → xs # ys } : Semigroup (List a))
+  λ(a : Type)
+→   { op = λ(xs : List a) → λ(ys : List a) → xs # ys }
+  : ./../Semigroup/Type (List a)

--- a/List/Traversable
+++ b/List/Traversable
@@ -1,17 +1,14 @@
-    let Traversable = ../Traversable/Type
+    let Traversable = ./../Traversable/Type
 
-in  let Applicative = ../Applicative/Type
+in  let Applicative = ./../Applicative/Type
 
-in  let liftA2 = ../Applicative/liftA2
+in  let liftA2 = ./../Applicative/liftA2
 
-in  let fold = ./Foldable .fold
+in  let fold = (./Foldable).fold
 
-in  { foldable =
-        ./Foldable
-    , functor =
-        ./Functor
-    , traversable =
-        { traverse =
+in      ./Foldable
+      ∧ ./Functor
+      ∧ { traverse =
               λ(f : Type → Type)
             → λ(applicative : Applicative f)
             → λ(a : Type)
@@ -26,12 +23,12 @@ in  { foldable =
                         (List b)
                         (List b)
                         (λ(x : b) → λ(xs : List b) → [ x ] # xs)
-
+              
               in  fold
                   a
                   ts
                   (f (List b))
                   (λ(x : a) → λ(y : f (List b)) → liftCons (g x) y)
-                  (applicative.applicative.pure (List b) ([] : List b))
+                  (applicative.pure (List b) ([] : List b))
         }
-    }
+    : Traversable List

--- a/Monad/Type
+++ b/Monad/Type
@@ -1,4 +1,4 @@
-    let Applicative = ./../Applicative/Type 
+    let Applicative = ./../Applicative/Type
 
 in  let Monad
         : (Type → Type) → Type

--- a/Monad/Type
+++ b/Monad/Type
@@ -1,11 +1,10 @@
-    let Functor = ../Functor/Type
-
-in  let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type 
 
 in  let Monad
         : (Type → Type) → Type
         =   λ(f : Type → Type)
-          → { bind : ∀(a : Type) → ∀(b : Type) → ∀(fa : f a) → ∀(k : a → f b) → f b }
+          → { bind :
+                ∀(a : Type) → ∀(b : Type) → ∀(fa : f a) → ∀(k : a → f b) → f b
+            }
 
-in    λ(f : Type → Type) ->
-      { applicative : Applicative f, monad : Monad f }
+in  λ(f : Type → Type) → Applicative f ⩓ Monad f

--- a/Monad/package.dhall
+++ b/Monad/package.dhall
@@ -1,66 +1,25 @@
-    let Monad = ./Type 
+    let Monad = ./Type
 
-in  let Module
-        :   ∀(f : Type → Type)
-          → ∀ ( monad
-              : { applicative :
-                    { applicative :
-                        { ap   :
-                              ∀(a : Type)
-                            → ∀(b : Type)
-                            → ∀(g : f (a → b))
-                            → ∀(fa : f a)
-                            → f b
-                        , pure : ∀(a : Type) → a → f a
-                        }
-                    , functor     :
-                        { map :
-                              ∀(a : Type)
-                            → ∀(b : Type)
-                            → ∀(g : a → b)
-                            → ∀(fa : f a)
-                            → f b
-                        }
-                    }
-                , monad       :
-                    { bind :
-                          ∀(a : Type)
-                        → ∀(b : Type)
-                        → ∀(fa : f a)
-                        → ∀(k : a → f b)
-                        → f b
-                    }
-                }
-              )
-          → { ap   :
-                ∀(a : Type) → ∀(b : Type) → ∀(g : f (a → b)) → ∀(fa : f a) → f b
-            , bind :
-                ∀(a : Type) → ∀(b : Type) → ∀(fa : f a) → ∀(k : a → f b) → f b
-            , map  :
-                ∀(a : Type) → ∀(b : Type) → ∀(g : a → b) → ∀(fa : f a) → f b
-            , pure : ∀(a : Type) → a → f a
-            }
-        =   λ(f : Type → Type)
-          → λ(monad : Monad f)
-          → { ap   =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : f (a → b))
-                → λ(fa : f a)
-                → monad.applicative.applicative.ap a b g fa
-            , bind =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : f a)
-                → λ(k : a → f b)
-                → monad.monad.bind a b fa k
-            , map  =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : a → b)
-                → λ(fa : f a)
-                → monad.applicative.functor.map a b g fa
-            , pure = λ(a : Type) → monad.applicative.applicative.pure a
-            }
-
-in  Module
+in    λ(f : Type → Type)
+    → λ(monad : Monad f)
+    → { ap =
+            λ(a : Type)
+          → λ(b : Type)
+          → λ(g : f (a → b))
+          → λ(fa : f a)
+          → monad.ap a b g fa
+      , bind =
+            λ(a : Type)
+          → λ(b : Type)
+          → λ(fa : f a)
+          → λ(k : a → f b)
+          → monad.bind a b fa k
+      , map =
+            λ(a : Type)
+          → λ(b : Type)
+          → λ(g : a → b)
+          → λ(fa : f a)
+          → monad.map a b g fa
+      , pure =
+          λ(a : Type) → monad.pure a
+      }

--- a/Monoid/Type
+++ b/Monoid/Type
@@ -1,3 +1,1 @@
-    let Semigroup = ../Semigroup/Type
-
-in  λ(m : Type) → { semigroup : Semigroup m, unit : m }
+λ(m : Type) → ./../Semigroup/Type m ⩓ { unit : m }

--- a/Optional/Applicative
+++ b/Optional/Applicative
@@ -1,27 +1,23 @@
 
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
-in  let fold = ./Foldable .fold
+in  let fold = (./Foldable).fold
 
-in  let map = ./Functor .map
+in  let map = (./Functor).map
 
-in  (   { functor =
-            ./Functor
-        , applicative =
-            { pure =
-                λ(a : Type) → λ(x : a) → [ x ] : Optional a
-            , ap =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(g : Optional (a → b))
-                → λ(fa : Optional a)
-                → fold
-                  (a → b)
-                  g
-                  (Optional b)
-                  (λ(k : a → b) → λ(o : Optional b) → map a b k fa)
-                  ([] : Optional b)
-            }
+in      ./Functor
+      ∧ { pure =
+            λ(a : Type) → λ(x : a) → [ x ] : Optional a
+        , ap =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(g : Optional (a → b))
+            → λ(fa : Optional a)
+            → fold
+              (a → b)
+              g
+              (Optional b)
+              (λ(k : a → b) → λ(o : Optional b) → map a b k fa)
+              ([] : Optional b)
         }
-      : Applicative Optional
-    )
+    : Applicative Optional

--- a/Optional/Foldable
+++ b/Optional/Foldable
@@ -1,13 +1,12 @@
 
-    let Foldable = ../Foldable/Type
+    let Foldable = ./../Foldable/Type
 
-in  (   { fold =
-              λ(a : Type)
-            → λ(ts : Optional a)
-            → λ(b : Type)
-            → λ(f : a → b → b)
-            → λ(z : b)
-            → Optional/fold a ts b (λ(x : a) → f x z) z
-        }
-      : Foldable Optional
-    )
+in    { fold =
+            λ(a : Type)
+          → λ(ts : Optional a)
+          → λ(b : Type)
+          → λ(f : a → b → b)
+          → λ(z : b)
+          → Optional/fold a ts b (λ(x : a) → f x z) z
+      }
+    : Foldable Optional

--- a/Optional/Functor
+++ b/Optional/Functor
@@ -1,6 +1,13 @@
-    let Functor = ../Functor/Type
-
-in  let map =
-          https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/Optional/map
-
-in  ({ map = map } : Functor Optional)
+  { map =
+        λ(a : Type)
+      → λ(b : Type)
+      → λ(f : a → b)
+      → λ(o : Optional a)
+      → Optional/fold
+        a
+        o
+        (Optional b)
+        (λ(x : a) → [ f x ] : Optional b)
+        ([] : Optional b)
+  }
+: ./../Functor/Type Optional

--- a/Optional/Monad
+++ b/Optional/Monad
@@ -1,20 +1,23 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
-in  let map = ./Functor .map
+in  let map = (./Functor).map
 
 in  let concat =
-          https://ipfs.io/ipfs/QmQ8w5PLcsNz56dMvRtq54vbuPe9cNnCCUXAQp6xLc6Ccx/Prelude/Optional/concat
+            λ(a : Type)
+          → λ(x : Optional (Optional a))
+          → Optional/fold
+            (Optional a)
+            x
+            (Optional a)
+            (λ(y : Optional a) → y)
+            ([] : Optional a)
 
-in  (   { applicative =
-            ./Applicative
-        , monad =
-            { bind =
-                  λ(a : Type)
-                → λ(b : Type)
-                → λ(fa : Optional a)
-                → λ(k : a → Optional b)
-                → concat b (map a (Optional b) k fa)
-            }
+in      ./Applicative
+      ∧ { bind =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(fa : Optional a)
+            → λ(k : a → Optional b)
+            → concat b (map a (Optional b) k fa)
         }
-      : Monad Optional
-    )
+    : Monad Optional

--- a/Optional/Traversable
+++ b/Optional/Traversable
@@ -1,13 +1,10 @@
-    let Traversable = ../Traversable/Type
+    let Traversable = ./../Traversable/Type
 
-in  let Applicative = ../Applicative/Type
+in  let Applicative = ./../Applicative/Type
 
-in  { foldable =
-        ./Foldable
-    , functor =
-        ./Functor
-    , traversable =
-        { traverse =
+in      ./Foldable
+      ∧ ./Functor
+      ∧ { traverse =
               λ(f : Type → Type)
             → λ(applicative : Applicative f)
             → λ(a : Type)
@@ -19,12 +16,12 @@ in  { foldable =
               ts
               (f (Optional b))
               (   λ(x : a)
-                → applicative.functor.map
+                → applicative.map
                   b
                   (Optional b)
                   (λ(y : b) → [ y ] : Optional b)
                   (g x)
               )
-              (applicative.applicative.pure (Optional b) ([] : Optional b))
+              (applicative.pure (Optional b) ([] : Optional b))
         }
-    }
+    : Traversable Optional

--- a/Reader/Applicative
+++ b/Reader/Applicative
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/Applicative  r ../Id/Type  ../Id/Applicative 
+λ(r : Type) → ./../ReaderT/Applicative r ./../Id/Type ./../Id/Applicative

--- a/Reader/Functor
+++ b/Reader/Functor
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/Functor  r ../Id/Type  ../Id/Functor 
+λ(r : Type) → ./../ReaderT/Functor r ./../Id/Type ./../Id/Functor

--- a/Reader/Monad
+++ b/Reader/Monad
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/Monad  r ../Id/Type  ../Id/Monad 
+λ(r : Type) → ./../ReaderT/Monad r ./../Id/Type ./../Id/Monad

--- a/Reader/ask
+++ b/Reader/ask
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/ask  r ../Id/Type  ../Id/Applicative 
+λ(r : Type) → ./../ReaderT/ask r ./../Id/Type ./../Id/Applicative

--- a/Reader/asks
+++ b/Reader/asks
@@ -1,2 +1,1 @@
-
-λ(r : Type) → ../ReaderT/asks  r ../Id/Type  ../Id/Applicative 
+λ(r : Type) → ./../ReaderT/asks r ./../Id/Type ./../Id/Applicative

--- a/Reader/local
+++ b/Reader/local
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/local  r ../Id/Type 
+λ(r : Type) → ./../ReaderT/local r ./../Id/Type

--- a/Reader/mapReader
+++ b/Reader/mapReader
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/mapReader  r ../Id/Type  ../Id/Functor 
+λ(r : Type) → ./../ReaderT/mapReader r ./../Id/Type ./../Id/Functor

--- a/Reader/package.dhall
+++ b/Reader/package.dhall
@@ -1,23 +1,19 @@
     let Reader = ./Type
 
 in    λ(r : Type)
-    → λ(a : Type)
-    → { mapReader =
-            λ(b : Type)
-          → λ(f : a → b)
-          → λ(reader : Reader r a)
-          → ./mapReader  r a b f reader
-      , Functor =
-          ./Functor  r
-      , Applicative =
-          ./Applicative  r
-      , Monad =
-          ./Monad  r
-      , runReader =
-          λ(reader : Reader r a) → λ(env : r) → reader env
-      , withReader =
-            λ(rPrime : Type)
-          → λ(f : rPrime → r)
-          → λ(reader : Reader r a)
-          → ./withReader  r a rPrime f reader
-      }
+    →   { mapReader =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(f : a → b)
+            → λ(reader : Reader r a)
+            → ./mapReader r a b f reader
+        , runReader =
+            λ(a : Type) → λ(reader : Reader r a) → λ(env : r) → reader env
+        , withReader =
+              λ(a : Type)
+            → λ(rPrime : Type)
+            → λ(f : rPrime → r)
+            → λ(reader : Reader r a)
+            → ./withReader r a rPrime f reader
+        }
+      ∧ ./Monad r

--- a/Reader/withReader
+++ b/Reader/withReader
@@ -1,1 +1,1 @@
-λ(r : Type) → ../ReaderT/withReader  r ../Id/Type 
+λ(r : Type) → ./../ReaderT/withReader r ./../Id/Type

--- a/ReaderT/Applicative
+++ b/ReaderT/Applicative
@@ -1,26 +1,19 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
 in  let ReaderT = ./Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
     → λ(applicative : Applicative m)
-    → (   { functor =
-              ./Functor r m applicative.functor
-          , applicative =
-              { pure =
-                    λ(a : Type)
-                  → λ(x : a)
-                  → λ(env : r)
-                  → applicative.applicative.pure a x
-              , ap =
-                    λ(a : Type)
-                  → λ(b : Type)
-                  → λ(g : ReaderT r m (a → b))
-                  → λ(fa : ReaderT r m a)
-                  → λ(env : r)
-                  → applicative.applicative.ap a b (g env) (fa env)
-              }
+    →     ./Functor r m applicative.{ map }
+        ∧ { pure =
+              λ(a : Type) → λ(x : a) → λ(env : r) → applicative.pure a x
+          , ap =
+                λ(a : Type)
+              → λ(b : Type)
+              → λ(g : ReaderT r m (a → b))
+              → λ(fa : ReaderT r m a)
+              → λ(env : r)
+              → applicative.ap a b (g env) (fa env)
           }
-        : Applicative (ReaderT r m)
-      )
+      : Applicative (ReaderT r m)

--- a/ReaderT/Functor
+++ b/ReaderT/Functor
@@ -1,17 +1,16 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type
 
 in  let ReaderT = ./Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
     → λ(functor : Functor m)
-    → (   { map =
-                λ(a : Type)
-              → λ(b : Type)
-              → λ(f : a → b)
-              → λ(fa : ReaderT r m a)
-              → λ(env : r)
-              → functor.map a b f (fa env)
-          }
-        : Functor (ReaderT r m)
-      )
+    →   { map =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(f : a → b)
+            → λ(fa : ReaderT r m a)
+            → λ(env : r)
+            → functor.map a b f (fa env)
+        }
+      : Functor (ReaderT r m)

--- a/ReaderT/Monad
+++ b/ReaderT/Monad
@@ -1,21 +1,17 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let ReaderT = ./Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
-    → (   { applicative =
-              ./Applicative  r m monad.applicative
-          , monad =
-              { bind =
-                    λ(a : Type)
-                  → λ(b : Type)
-                  → λ(fa : ReaderT r m a)
-                  → λ(k : a → ReaderT r m b)
-                  → λ(env : r)
-                  → monad.monad.bind a b (fa env) (λ(x : a) → k x env)
-              }
+    →     ./Applicative r m monad.{ ap, map, pure }
+        ∧ { bind =
+                λ(a : Type)
+              → λ(b : Type)
+              → λ(fa : ReaderT r m a)
+              → λ(k : a → ReaderT r m b)
+              → λ(env : r)
+              → monad.bind a b (fa env) (λ(x : a) → k x env)
           }
-        : Monad (ReaderT r m)
-      )
+      : Monad (ReaderT r m)

--- a/ReaderT/Transformer
+++ b/ReaderT/Transformer
@@ -1,17 +1,16 @@
-    let Transformer = ../Transformer/Type
+    let Transformer = ./../Transformer/Type
 
-in  let Monad = ../Monad/Type
+in  let Monad = ./../Monad/Type
 
 in  let ReaderT = ./Type
 
 in    λ(r : Type)
-    → (   { lift =
-                λ(m : Type → Type)
-              → λ(monad : Monad m)
-              → λ(a : Type)
-              → λ(ma : m a)
-              → λ(env : r)
-              → ma
-          }
-        : Transformer (ReaderT r)
-      )
+    →   { lift =
+              λ(m : Type → Type)
+            → λ(monad : Monad m)
+            → λ(a : Type)
+            → λ(ma : m a)
+            → λ(env : r)
+            → ma
+        }
+      : Transformer (ReaderT r)

--- a/ReaderT/ask
+++ b/ReaderT/ask
@@ -1,7 +1,7 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
     → λ(applicative : Applicative m)
     → λ(env : r)
-    → applicative.applicative.pure r env
+    → applicative.pure r env

--- a/ReaderT/asks
+++ b/ReaderT/asks
@@ -1,4 +1,4 @@
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
@@ -6,4 +6,4 @@ in    λ(r : Type)
     → λ(a : Type)
     → λ(f : r → a)
     → λ(env : r)
-    → applicative.applicative.pure a (f env)
+    → applicative.pure a (f env)

--- a/ReaderT/mapReader
+++ b/ReaderT/mapReader
@@ -1,6 +1,6 @@
-    let ReaderT = ./Type 
+    let ReaderT = ./Type
 
-in  let Functor = ../Functor/Type
+in  let Functor = ./../Functor/Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
@@ -10,4 +10,4 @@ in    λ(r : Type)
     → λ(f : a → b)
     → λ(reader : ReaderT r m a)
     → λ(newR : r)
-    → (./Functor  r m functor).map a b f reader newR
+    → (./Functor r m functor).map a b f reader newR

--- a/ReaderT/package.dhall
+++ b/ReaderT/package.dhall
@@ -1,28 +1,22 @@
     let ReaderT = ./Type
 
-in  let Functor = ../Functor/Type
-
-in  let Applicative = ../Applicative/Type
-
-in  let Monad = ../Monad/Type
+in  let Monad = ./../Monad/Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)
-    → λ(a : Type)
-    → { Functor =
-          λ(functor : Functor m) → ./Functor  r m functor
-      , Applicative =
-          λ(applicative : Applicative m) → ./Applicative  r m applicative
-      , Monad =
-          λ(monad : Monad m) → ./Monad  r m monad
-      , Transformer =
-          ./Transformer  r
-      , runReaderT =
-          λ(reader : ReaderT r m a) → λ(env : r) → reader env
-      , ask =
-          λ(applicative : Applicative m) → ./ask  r m applicative
-      , asks =
-          λ(applicative : Applicative m) → ./asks  r m applicative a
-      , local =
-          λ(f : r → r) → λ(reader : ReaderT r m a) → ./local  r m a f reader
-      }
+    → λ(monad : Monad m)
+    →   { lift =
+            λ(a : Type) → (./Transformer r).lift m monad a
+        , runReaderT =
+            λ(a : Type) → λ(reader : ReaderT r m a) → λ(env : r) → reader env
+        , ask =
+            ./ask r m monad.{ ap, map, pure }
+        , asks =
+            λ(a : Type) → ./asks r m monad.{ ap, map, pure } a
+        , local =
+              λ(a : Type)
+            → λ(f : r → r)
+            → λ(reader : ReaderT r m a)
+            → ./local r m a f reader
+        }
+      ∧ ./Monad r m monad

--- a/ReaderT/withReader
+++ b/ReaderT/withReader
@@ -1,4 +1,4 @@
-    let ReaderT = ./Type 
+    let ReaderT = ./Type
 
 in    λ(r : Type)
     → λ(m : Type → Type)

--- a/State/Applicative
+++ b/State/Applicative
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/Applicative  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/Applicative s ./../Id/Type ./../Id/Monad

--- a/State/Functor
+++ b/State/Functor
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/Functor  s ../Id/Type  ../Id/Functor 
+λ(s : Type) → ./../StateT/Functor s ./../Id/Type ./../Id/Functor

--- a/State/Monad
+++ b/State/Monad
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/Monad  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/Monad s ./../Id/Type ./../Id/Monad

--- a/State/Type
+++ b/State/Type
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/Type  s ../Id/Type 
+λ(s : Type) → ./../StateT/Type s ./../Id/Type

--- a/State/evalState
+++ b/State/evalState
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/evalState  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/evalState s ./../Id/Type ./../Id/Monad

--- a/State/execState
+++ b/State/execState
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/execState  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/execState s ./../Id/Type ./../Id/Monad

--- a/State/get
+++ b/State/get
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/get  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/get s ./../Id/Type ./../Id/Monad

--- a/State/gets
+++ b/State/gets
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/gets  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/gets s ./../Id/Type ./../Id/Monad

--- a/State/mapState
+++ b/State/mapState
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/mapState  s ../Id/Type  ../Id/Functor 
+λ(s : Type) → ./../StateT/mapState s ./../Id/Type ./../Id/Functor

--- a/State/modify
+++ b/State/modify
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/modify  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/modify s ./../Id/Type ./../Id/Monad

--- a/State/package.dhall
+++ b/State/package.dhall
@@ -1,27 +1,21 @@
     let State = ./Type
 
 in    λ(s : Type)
-    → λ(a : Type)
-    → { evalState =
-          ./evalState  s a
-      , execState =
-          ./execState  s a
-      , get =
-          ./get  s
-      , mapState =
-          ./mapState  s a
-      , modify =
-          ./modify  s
-      , put =
-          ./put  s
-      , runState =
-          λ(state : State s a) → λ(new : s) → state new
-      , Applicative =
-          ./Applicative  s
-      , Functor =
-          ./Functor  s
-      , Monad =
-          ./Monad  s
-      , withState =
-          ./withState  s a
-      }
+    →   { evalState =
+            λ(a : Type) → ./evalState s a
+        , execState =
+            λ(a : Type) → ./execState s a
+        , get =
+            λ(a : Type) → ./get s
+        , mapState =
+            λ(a : Type) → ./mapState s a
+        , modify =
+            ./modify s
+        , put =
+            ./put s
+        , runState =
+            λ(a : Type) → λ(state : State s a) → λ(new : s) → state new
+        , withState =
+            λ(a : Type) → ./withState s a
+        }
+      ∧ ./Monad s

--- a/State/put
+++ b/State/put
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/put  s ../Id/Type  ../Id/Monad 
+λ(s : Type) → ./../StateT/put s ./../Id/Type ./../Id/Monad

--- a/State/withState
+++ b/State/withState
@@ -1,1 +1,1 @@
-λ(s : Type) → ../StateT/withState  s ../Id/Type 
+λ(s : Type) → ./../StateT/withState s ./../Id/Type

--- a/StateT/Applicative
+++ b/StateT/Applicative
@@ -1,50 +1,40 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
-in  let Applicative = ../Applicative/Type
+in  let Applicative = ./../Applicative/Type
 
 in  let StateT = ./Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
-    → (   { functor =
-              ./Functor  s m monad.applicative.functor
-          , applicative =
-              { ap =
-                    λ(a : Type)
-                  → λ(b : Type)
-                  → λ(g : StateT s m (a → b))
-                  → λ(fa : StateT s m a)
-                  → λ(new : s)
-                  →     let fk = g new
-
-                    in  monad.monad.bind
-                        { val : a → b, state : s }
-                        { val : b, state : s }
-                        fk
-                        (   λ(k : { val : a → b, state : s })
-                          →     let res = fa k.state
-
-                            in  monad.applicative.functor.map
-                                { val : a, state : s }
-                                { val : b, state : s }
-                                (   λ(final : { val : a, state : s })
-                                  → { val =
-                                        k.val final.val
-                                    , state =
-                                        final.state
-                                    }
-                                )
-                                res
-                        )
-              , pure =
-                    λ(a : Type)
-                  → λ(x : a)
-                  → λ(env : s)
-                  → monad.applicative.applicative.pure
-                    { val : a, state : s }
-                    { val = x, state = env }
-              }
+    →     ./Functor s m monad.{ map }
+        ∧ { ap =
+                λ(a : Type)
+              → λ(b : Type)
+              → λ(g : StateT s m (a → b))
+              → λ(fa : StateT s m a)
+              → λ(new : s)
+              →     let fk = g new
+                
+                in  monad.bind
+                    { val : a → b, state : s }
+                    { val : b, state : s }
+                    fk
+                    (   λ(k : { val : a → b, state : s })
+                      →     let res = fa k.state
+                        
+                        in  monad.map
+                            { val : a, state : s }
+                            { val : b, state : s }
+                            (   λ(final : { val : a, state : s })
+                              → { val = k.val final.val, state = final.state }
+                            )
+                            res
+                    )
+          , pure =
+                λ(a : Type)
+              → λ(x : a)
+              → λ(env : s)
+              → monad.pure { val : a, state : s } { val = x, state = env }
           }
-        : Applicative (StateT s m)
-      )
+      : Applicative (StateT s m)

--- a/StateT/Functor
+++ b/StateT/Functor
@@ -1,23 +1,22 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type
 
 in  let StateT = ./Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(functor : Functor m)
-    → (   { map =
-                λ(a : Type)
-              → λ(b : Type)
-              → λ(f : a → b)
-              → λ(fa : StateT s m a)
-              → λ(new : s)
-              → functor.map
-                { val : a, state : s }
-                { val : b, state : s }
-                (   λ(res : { val : a, state : s })
-                  → { val = f res.val, state = res.state }
-                )
-                (fa new)
-          }
-        : Functor (StateT s m)
-      )
+    →   { map =
+              λ(a : Type)
+            → λ(b : Type)
+            → λ(f : a → b)
+            → λ(fa : StateT s m a)
+            → λ(new : s)
+            → functor.map
+              { val : a, state : s }
+              { val : b, state : s }
+              (   λ(res : { val : a, state : s })
+                → { val = f res.val, state = res.state }
+              )
+              (fa new)
+        }
+      : Functor (StateT s m)

--- a/StateT/Monad
+++ b/StateT/Monad
@@ -1,25 +1,21 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let StateT = ./Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
-    → (   { applicative =
-              ./Applicative  s m monad
-          , monad =
-              { bind =
-                    λ(a : Type)
-                  → λ(b : Type)
-                  → λ(fa : StateT s m a)
-                  → λ(k : a → StateT s m b)
-                  → λ(new : s)
-                  → monad.monad.bind
-                    { val : a, state : s }
-                    { val : b, state : s }
-                    (fa new)
-                    (λ(res : { val : a, state : s }) → k res.val res.state)
-              }
+    →     ./Applicative s m monad
+        ∧ { bind =
+                λ(a : Type)
+              → λ(b : Type)
+              → λ(fa : StateT s m a)
+              → λ(k : a → StateT s m b)
+              → λ(new : s)
+              → monad.bind
+                { val : a, state : s }
+                { val : b, state : s }
+                (fa new)
+                (λ(res : { val : a, state : s }) → k res.val res.state)
           }
-        : Monad (StateT s m)
-      )
+      : Monad (StateT s m)

--- a/StateT/Transformer
+++ b/StateT/Transformer
@@ -1,25 +1,22 @@
-    let Transformer = ../Transformer/Type
+    let Transformer = ./../Transformer/Type
 
-in  let Monad = ../Monad/Type
+in  let Monad = ./../Monad/Type
 
 in  let StateT = ./Type
 
 in    λ(s : Type)
-    → (   { lift =
-                λ(m : Type → Type)
-              → λ(monad : Monad m)
-              → λ(a : Type)
-              → λ(ma : m a)
-              → λ(env : s)
-              → monad.monad.bind
-                a
-                { val : a, state : s }
-                ma
-                (   λ(x : a)
-                  → monad.applicative.applicative.pure
-                    { val : a, state : s }
-                    { val = x, state = env }
-                )
-          }
-        : Transformer (StateT s)
-      )
+    →   { lift =
+              λ(m : Type → Type)
+            → λ(monad : Monad m)
+            → λ(a : Type)
+            → λ(ma : m a)
+            → λ(env : s)
+            → monad.bind
+              a
+              { val : a, state : s }
+              ma
+              (   λ(x : a)
+                → monad.pure { val : a, state : s } { val = x, state = env }
+              )
+        }
+      : Transformer (StateT s)

--- a/StateT/evalState
+++ b/StateT/evalState
@@ -1,4 +1,4 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let StateT = ./Type
 
@@ -8,10 +8,8 @@ in    λ(s : Type)
     → λ(a : Type)
     → λ(state : StateT s m a)
     → λ(env : s)
-    → monad.monad.bind
+    → monad.bind
       { val : a, state : s }
       a
       (state env)
-      (   λ(res : { val : a, state : s })
-        → monad.applicative.applicative.pure a res.val
-      )
+      (λ(res : { val : a, state : s }) → monad.pure a res.val)

--- a/StateT/execState
+++ b/StateT/execState
@@ -1,4 +1,4 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let StateT = ./Type
 
@@ -8,10 +8,8 @@ in    λ(s : Type)
     → λ(a : Type)
     → λ(state : StateT s m a)
     → λ(env : s)
-    → monad.monad.bind
+    → monad.bind
       { val : a, state : s }
       s
       (state env)
-      (   λ(res : { val : a, state : s })
-        → monad.applicative.applicative.pure s res.state
-      )
+      (λ(res : { val : a, state : s }) → monad.pure s res.state)

--- a/StateT/get
+++ b/StateT/get
@@ -1,9 +1,7 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
     → λ(env : s)
-    → monad.applicative.applicative.pure
-      { val : s, state : s }
-      { val = env, state = env }
+    → monad.pure { val : s, state : s } { val = env, state = env }

--- a/StateT/gets
+++ b/StateT/gets
@@ -1,4 +1,4 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let StateMonad = ./Monad
 
@@ -7,6 +7,4 @@ in    λ(s : Type)
     → λ(monad : Monad m)
     → λ(a : Type)
     → λ(f : s → a)
-    →     let map = (StateMonad s m monad).applicative.functor.map
-
-      in  map s a f (./get  s m monad)
+    → let map = (StateMonad s m monad).map in map s a f (./get s m monad)

--- a/StateT/mapState
+++ b/StateT/mapState
@@ -1,4 +1,4 @@
   λ(s : Type)
 → λ(m : Type → Type)
-→ λ(functor : ../Functor/Type  m)
-→ (../StateT/Functor  s m functor).map
+→ λ(functor : ./../Functor/Type m)
+→ (./../StateT/Functor s m functor).map

--- a/StateT/modify
+++ b/StateT/modify
@@ -1,4 +1,4 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in  let StateMonad = ./Monad
 
@@ -6,6 +6,6 @@ in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
     → λ(f : s → s)
-    →     let bind = (StateMonad s m monad).monad.bind
-
-      in  bind s {} (./get  s m monad) (λ(state : s) → ./put  s m monad (f state))
+    →     let bind = (StateMonad s m monad).bind
+      
+      in  bind s {} (./get s m monad) (λ(state : s) → ./put s m monad (f state))

--- a/StateT/package.dhall
+++ b/StateT/package.dhall
@@ -1,34 +1,25 @@
     let StateT = ./Type
 
-in  let Functor = ../Functor/Type
-
-in  let Applicative = ../Applicative/Type
-
-in  let Monad = ../Monad/Type
+in  let Monad = ./../Monad/Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
-    → λ(a : Type)
-    → { Functor =
-          λ(functor : Functor m) → ./Functor  s m functor
-      , Applicative =
-          λ(monad : Monad m) → ./Applicative  s m monad
-      , Monad =
-          λ(monad : Monad m) → ./Monad  s m monad
-      , Transformer =
-          ./Transformer  s
-      , runState =
-          λ(state : StateT s m a) → λ(new : s) → state new
-      , evalState =
-          λ(monad : Monad m) → ./evalState  s m monad a
-      , execState =
-          λ(monad : Monad m) → ./execState  s m monad a
-      , get =
-          λ(monad : Monad m) → ./get  s m monad
-      , gets =
-          λ(monad : Monad m) → ./gets  s m monad a
-      , put =
-          λ(monad : Monad m) → ./put  s m monad
-      , modify =
-          λ(monad : Monad m) → ./modify  s m monad
-      }
+    → λ(monad : Monad m)
+    →   { lift =
+            λ(a : Type) → (./Transformer s).lift m monad a
+        , runState =
+            λ(a : Type) → λ(state : StateT s m a) → λ(new : s) → state new
+        , evalState =
+            λ(a : Type) → ./evalState s m monad a
+        , execState =
+            λ(a : Type) → ./execState s m monad a
+        , get =
+            ./get s m monad
+        , gets =
+            λ(a : Type) → ./gets s m monad a
+        , put =
+            λ(a : Type) → ./put s m monad
+        , modify =
+            λ(a : Type) → ./modify s m monad
+        }
+      ∧ ./Monad s m monad

--- a/StateT/put
+++ b/StateT/put
@@ -1,10 +1,8 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)
     → λ(monad : Monad m)
     → λ(new : s)
     → λ(env : s)
-    → monad.applicative.applicative.pure
-      { val : {}, state : s }
-      { val = {=}, state = new }
+    → monad.pure { val : {}, state : s } { val = {=}, state = new }

--- a/StateT/withState
+++ b/StateT/withState
@@ -1,4 +1,4 @@
-    let StateT = ./Type 
+    let StateT = ./Type
 
 in    λ(s : Type)
     → λ(m : Type → Type)

--- a/Transformer/Type
+++ b/Transformer/Type
@@ -1,10 +1,6 @@
-    let Monad = ../Monad/Type
+    let Monad = ./../Monad/Type
 
 in    λ(t : (Type → Type) → Type → Type)
     → { lift :
-            ∀(m : Type → Type)
-          → ∀(monad : Monad m)
-          → ∀(a : Type)
-          → ∀(ma : m a)
-          → t m a
+          ∀(m : Type → Type) → ∀(monad : Monad m) → ∀(a : Type) → m a → t m a
       }

--- a/Traversable/Type
+++ b/Traversable/Type
@@ -1,22 +1,19 @@
-    let Functor = ../Functor/Type
+    let Functor = ./../Functor/Type
 
-in  let Foldable = ../Foldable/Type
+in  let Foldable = ./../Foldable/Type
 
-in  let Applicative = ../Applicative/Type
+in  let Applicative = ./../Applicative/Type
 
-in    λ(t : Type → Type)
-    → { foldable :
-          Foldable t
-      , functor :
-          Functor t
-      , traversable :
-          { traverse :
-                ∀(f : Type → Type)
-              → ∀(applicative : Applicative f)
-              → ∀(a : Type)
-              → ∀(b : Type)
-              → ∀(g : a → f b)
-              → ∀(ts : t a)
-              → f (t b)
-          }
-      }
+in  let Traversable =
+            λ(t : Type → Type)
+          → { traverse :
+                  ∀(f : Type → Type)
+                → ∀(applicative : Applicative f)
+                → ∀(a : Type)
+                → ∀(b : Type)
+                → (a → f b)
+                → t a
+                → f (t b)
+            }
+
+in  λ(t : Type → Type) → Foldable t ⩓ Functor t ⩓ Traversable t

--- a/Traversable/fromTraverse
+++ b/Traversable/fromTraverse
@@ -1,34 +1,31 @@
   λ(t : Type → Type)
 → λ ( traverse
     :   ∀(f : Type → Type)
-      → ∀(applicative : ../Applicative/Type  f)
+      → ∀(applicative : ./../Applicative/Type f)
       → ∀(a : Type)
       → ∀(b : Type)
       → ∀(g : a → f b)
       → ∀(ts : t a)
       → f (t b)
     )
-→ (   { foldable =
-          { fold =
-                λ(a : Type)
-              → λ(ts : t a)
-              → λ(b : Type)
-              → λ(f : a → b → b)
-              → λ(z : b)
-              → ( traverse
-                  (../State/Type  b)
-                  (../State/Applicative  b)
-                  a
-                  a
-                  (λ(x : a) → λ(y : b) → { state = f x y, val = x })
-                  ts
-                  z
-                ).state
-          }
-      , functor =
-          { map = traverse ../Id/Type  ../Id/Applicative  }
-      , traversable =
-          { traverse = traverse }
-      }
-    : ./Type  t
-  )
+→   { fold =
+          λ(a : Type)
+        → λ(ts : t a)
+        → λ(b : Type)
+        → λ(f : a → b → b)
+        → λ(z : b)
+        → ( traverse
+            (./../State/Type b)
+            (./../State/Applicative b)
+            a
+            a
+            (λ(x : a) → λ(y : b) → { state = f x y, val = x })
+            ts
+            z
+          ).state
+    , map =
+        traverse ./../Id/Type ./../Id/Applicative
+    , traverse =
+        traverse
+    }
+  : ./Type t

--- a/Traversable/sequence
+++ b/Traversable/sequence
@@ -1,7 +1,7 @@
 
-    let Applicative = ../Applicative/Type
+    let Applicative = ./../Applicative/Type
 
-in  let Traversable = ../Traversable/Type
+in  let Traversable = ./../Traversable/Type
 
 in    λ(t : Type → Type)
     → λ(traversable : Traversable t)
@@ -9,4 +9,4 @@ in    λ(t : Type → Type)
     → λ(applicative : Applicative f)
     → λ(a : Type)
     → λ(ts : t (f a))
-    → traversable.traversable.traverse f applicative (f a) a (λ(x : f a) → x) ts
+    → traversable.traverse f applicative (f a) a (λ(x : f a) → x) ts


### PR DESCRIPTION
Fixes #14 

Uses `//\\` operator to merge the typeclass records and fixes all call sites of the old way of record access e.g. `monad.applicative.applicative.ap` 🙄 .

Cleaned up some code along the way and heavy use of `dhall lint`