### PR TITLE
Introduce the right Kan extension

### DIFF
--- a/Codensity/Functor
+++ b/Codensity/Functor
@@ -1,11 +1,1 @@
-  λ(m : Type → Type)
-→   { map =
-          λ(a : Type)
-        → λ(b : Type)
-        → λ(f : a → b)
-        → λ(codensity : ./Type m a)
-        → λ(c : Type)
-        → λ(k : b → m c)
-        → codensity c (λ(x : a) → k (f x))
-    }
-  : ./../Functor/Type (./Type m)
+λ(m : Type → Type) → ./../Ran/Functor m m

--- a/Codensity/Type
+++ b/Codensity/Type
@@ -1,1 +1,1 @@
-λ(m : Type → Type) → λ(a : Type) → ∀(b : Type) → (a → m b) → m b
+λ(m : Type → Type) → ./../Ran/Type m m

--- a/Codensity/lower
+++ b/Codensity/lower
@@ -1,5 +1,1 @@
-  λ(m : Type → Type)
-→ λ(app : ./../Applicative/Type m)
-→ λ(a : Type)
-→ λ(codensity : ./Type m a)
-→ codensity a (app.pure a)
+λ(m : Type → Type) → ./../Ran/lower m m

--- a/Ran/Functor
+++ b/Ran/Functor
@@ -1,0 +1,12 @@
+  λ(f : Type → Type)
+→ λ(g : Type → Type)
+→   { map =
+          λ(a : Type)
+        → λ(b : Type)
+        → λ(h : a → b)
+        → λ(ran : ./Type f g a)
+        → λ(c : Type)
+        → λ(k : b → f c)
+        → ran c (λ(x : a) → k (h x))
+    }
+  : ./../Functor/Type (./Type f g)

--- a/Ran/Type
+++ b/Ran/Type
@@ -1,0 +1,4 @@
+  λ(f : Type → Type)
+→ λ(g : Type → Type)
+→ λ(a : Type)
+→ ∀(b : Type) → (a → f b) → g b

--- a/Ran/lower
+++ b/Ran/lower
@@ -1,0 +1,6 @@
+  λ(f : Type → Type)
+→ λ(g : Type → Type)
+→ λ(applicative : ./../Applicative/Type f)
+→ λ(a : Type)
+→ λ(ran : ./Type f g a)
+→ ran a (applicative.pure a)

--- a/Yoneda/Functor
+++ b/Yoneda/Functor
@@ -1,20 +1,2 @@
-    let compose =
-            λ(a : Type)
-          → λ(b : Type)
-          → λ(c : Type)
-          → λ(f : b → c)
-          → λ(g : a → b)
-          → λ(x : a)
-          → f (g x)
-
-in    λ(f : Type → Type)
-    →   { map =
-              λ(a : Type)
-            → λ(b : Type)
-            → λ(g : a → b)
-            → λ(yoneda : ./Type f a)
-            → λ(c : Type)
-            → λ(k : b → c)
-            → yoneda c (compose a b c k g)
-        }
-      : ./../Functor/Type (./Type f)
+  λ(f : Type → Type)
+→ ./../Ran/Functor ./../Id/Type f : ./../Functor/Type (./Type f)

--- a/Yoneda/Type
+++ b/Yoneda/Type
@@ -1,1 +1,1 @@
-λ(f : Type → Type) → λ(a : Type) → ∀(b : Type) → (a → b) → f b
+./../Ran/Type ./../Id/Type

--- a/Yoneda/lower
+++ b/Yoneda/lower
@@ -1,4 +1,1 @@
-  λ(f : Type → Type)
-→ λ(a : Type)
-→ λ(yoneda : ./Type f a)
-→ yoneda a (λ(x : a) → x)
+λ(f : Type → Type) → ./../Ran/lower ./../Id/Type f ./../Id/Applicative


### PR DESCRIPTION
Re: #30

First go an implementing `Ran f g a`. There's more that could be moved from Codensity/Yoneda, but requires some additional concepts. E.g.
* We could define `Applicative (Ran f g)` if we have a an isomorphism between `f` and `g` (or at least `forall (a : Type) -> f a -> g a` and `forall (a : Type) -> g a -> f a`).
* We could define `Ran/lower` if we have `forall (a : Type) -> f a -> a` (I think).

I didn't want to add these just things for the sake of redefining everything in terms of Ran, but can if they're wanted.

In any case, let me know if this is what we're thinking and if anything needs to change!