### PR TITLE
Free monads (church encoding)

### DIFF
--- a/Free/Type
+++ b/Free/Type
@@ -1,0 +1,5 @@
+let Free
+    : ∀(f : Type → Type) → ∀(a : Type) → Type
+    = λ(f : Type → Type) → λ(a : Type) → ∀(r : Type) → (a → r) → (f r → r) → r
+
+in  Free

--- a/Free/ap
+++ b/Free/ap
@@ -1,0 +1,18 @@
+let Free = ./Type
+let ap
+    :   ∀(f : Type -> Type)
+     -> ∀(a : Type)
+     -> ∀(b : Type)
+     -> Free f (a -> b)
+     -> Free f a
+     -> Free f b
+    =   λ(f : Type -> Type)
+     -> λ(a : Type)
+     -> λ(b : Type)
+     -> λ(mf : Free f (a -> b))
+     -> λ(mx : Free f a)
+     -> λ(r : Type)
+     -> λ(kp : b -> r)
+     -> λ(kf : f r -> r)
+     -> mf r (\(ff : a -> b) -> mx r (\(xx : a) -> kp (ff xx)) kf) kf
+in  ap

--- a/Free/applicative
+++ b/Free/applicative
@@ -1,0 +1,9 @@
+let Applicative = ../Applicative/Type
+
+let Free = ./Type
+
+let applicative
+    : ∀(f : Type → Type) → Applicative (Free f)
+    = λ(f : Type → Type) → ./functor f ∧ { ap = ./ap f, pure = ./pure f }
+
+in  applicative

--- a/Free/bind
+++ b/Free/bind
@@ -1,0 +1,20 @@
+let Free = ./Type
+
+let bind
+    :   ∀(f : Type → Type)
+      → ∀(a : Type)
+      → ∀(b : Type)
+      → Free f a
+      → (a → Free f b)
+      → Free f b
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(b : Type)
+      → λ(m : Free f a)
+      → λ(g : a → Free f b)
+      → λ(r : Type)
+      → λ(kp : b → r)
+      → λ(kf : f r → r)
+      → m r (λ(x : a) → g x r kp kf) kf
+
+in  bind

--- a/Free/foldFree
+++ b/Free/foldFree
@@ -1,0 +1,23 @@
+let Free = ./Type
+
+let Monad = ../Monad/Type
+
+let monad = ../Monad/package.dhall
+
+let foldFree
+    :   ∀(f : Type → Type)
+      → ∀(g : Type → Type)
+      → Monad g
+      → ∀(a : Type)
+      → (∀(x : Type) → f x → g x)
+      → Free f a
+      → g a
+    =   λ(f : Type → Type)
+      → λ(g : Type → Type)
+      → λ(MG : Monad g)
+      → λ(a : Type)
+      → λ(n : ∀(x : Type) → f x → g x)
+      → λ(m : Free f a)
+      → m (g a) (MG.pure a) (λ(q : f (g a)) → (monad g MG).join a (n (g a) q))
+
+in  foldFree

--- a/Free/functor
+++ b/Free/functor
@@ -1,0 +1,9 @@
+let Functor = ../Functor/Type
+
+let Free = ./Type
+
+let functor
+    : ∀(f : Type → Type) → Functor (Free f)
+    = λ(f : Type → Type) → { map = ./map f }
+
+in  functor

--- a/Free/hoist
+++ b/Free/hoist
@@ -1,0 +1,20 @@
+let Free = ./Type
+
+let hoist
+    :   ∀(f : Type → Type)
+      → ∀(g : Type → Type)
+      → ∀(a : Type)
+      → (∀(x : Type) → f x → g x)
+      → Free f a
+      → Free g a
+    =   λ(f : Type → Type)
+      → λ(g : Type → Type)
+      → λ(a : Type)
+      → λ(n : ∀(x : Type) → f x → g x)
+      → λ(m : Free f a)
+      → λ(r : Type)
+      → λ(kp : a → r)
+      → λ(kf : g r → r)
+      → m r kp (λ(q : f r) → kf (n r q))
+
+in  hoist

--- a/Free/iter
+++ b/Free/iter
@@ -1,0 +1,11 @@
+let Free = ./Type
+
+let iter
+    : ∀(f : Type → Type) → ∀(a : Type) → (f a → a) → Free f a → a
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(phi : f a → a)
+      → λ(m : Free f a)
+      → m a (λ(x : a) → x) phi
+
+in  iter

--- a/Free/iterA
+++ b/Free/iterA
@@ -1,0 +1,21 @@
+let Applicative = ../Applicative/Type
+
+let Free = ./Type
+
+let iterA
+    :   ∀(f : Type → Type)
+      → ∀(g : Type → Type)
+      → Applicative g
+      → ∀(a : Type)
+      → (f (g a) → g a)
+      → Free f a
+      → g a
+    =   λ(f : Type → Type)
+      → λ(g : Type → Type)
+      → λ(AG : Applicative g)
+      → λ(a : Type)
+      → λ(phi : f (g a) → g a)
+      → λ(m : Free f a)
+      → m (g a) (AG.pure a) phi
+
+in  iterA

--- a/Free/liftF
+++ b/Free/liftF
@@ -1,0 +1,16 @@
+let Free = ./Type
+
+let Functor = ../Functor/Type
+
+let liftF
+    : ∀(f : Type → Type) → Functor f → ∀(a : Type) → f a → Free f a
+    =   λ(f : Type → Type)
+      → λ(FF : Functor f)
+      → λ(a : Type)
+      → λ(x : f a)
+      → λ(r : Type)
+      → λ(kp : a → r)
+      → λ(kf : f r → r)
+      → kf (FF.map a r kp x)
+
+in  liftF

--- a/Free/map
+++ b/Free/map
@@ -1,0 +1,20 @@
+let Free = ./Type
+
+let map
+    :   ∀(f : Type → Type)
+      → ∀(a : Type)
+      → ∀(b : Type)
+      → (a → b)
+      → Free f a
+      → Free f b
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(b : Type)
+      → λ(g : a → b)
+      → λ(m : Free f a)
+      → λ(r : Type)
+      → λ(kp : b → r)
+      → λ(kf : f r → r)
+      → m r (λ(x : a) → kp (g x)) kf
+
+in  map

--- a/Free/monad
+++ b/Free/monad
@@ -1,0 +1,9 @@
+let Monad = ../Monad/Type
+
+let Free = ./Type
+
+let monad
+    : ∀(f : Type → Type) → Monad (Free f)
+    = λ(f : Type → Type) → ./applicative f ∧ { bind = ./bind f }
+
+in  monad

--- a/Free/package.dhall
+++ b/Free/package.dhall
@@ -1,0 +1,19 @@
+let Free = ./Type
+
+let Functor = ../Functor/Type
+
+let Applicative = ../Applicative/Type
+
+in    λ(f : Type → Type)
+    →   { iter =
+            ./iter f
+        , iterA =
+            λ(g : Type → Type) → λ(AG : Applicative g) → ./iterA f g AG
+        , retract =
+            ./retract f
+        , wrap =
+            ./wrap f
+        , liftF = \(FF : Functor f) -> ./liftF f FF
+        , foldFree = ./foldFree f
+        }
+      ∧ ./monad f ⫽ ./transformer

--- a/Free/pure
+++ b/Free/pure
@@ -1,0 +1,13 @@
+let Free = ./Type
+
+let pure
+    : ∀(f : Type → Type) → ∀(a : Type) → a → Free f a
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(x : a)
+      → λ(r : Type)
+      → λ(kp : a → r)
+      → λ(kf : f r → r)
+      → kp x
+
+in  pure

--- a/Free/retract
+++ b/Free/retract
@@ -1,0 +1,15 @@
+let Monad = ../Monad/Type
+
+let monad = ../Monad/package.dhall
+
+let Free = ./Type
+
+let retract
+    : ∀(f : Type → Type) → ∀(a : Type) → Monad f → Free f a → f a
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(MF : Monad f)
+      → λ(m : Free f a)
+      → m (f a) (MF.pure a) ((monad f MF).join a)
+
+in  retract

--- a/Free/transformer
+++ b/Free/transformer
@@ -1,0 +1,18 @@
+let Functor = ../Functor/Type
+
+let Monad = ../Monad/Type
+
+let Transformer = ../Transformer/Type
+
+let Free = ./Type
+
+let transformer
+    : Transformer Free
+    = { lift =
+            λ(m : Type → Type)
+          → λ(MM : Monad m)
+          → λ(a : Type)
+          → ./liftF m { map = MM.map } a
+      }
+
+in  transformer

--- a/Free/wrap
+++ b/Free/wrap
@@ -1,0 +1,16 @@
+let Functor = ../Functor/Type
+
+let Free = ./Type
+
+let wrap
+    : ∀(f : Type → Type) → ∀(a : Type) → Functor f → f (Free f a) → Free f a
+    =   λ(f : Type → Type)
+      → λ(a : Type)
+      → λ(FF : Functor f)
+      → λ(x : f (Free f a))
+      → λ(r : Type)
+      → λ(kp : a → r)
+      → λ(kf : f r → r)
+      → kf (FF.map (Free f a) r (λ(m : Free f a) → m r kp kf) x)
+
+in  wrap


### PR DESCRIPTION
Hi all, just wanted to first say thanks for the great package :)

I've been playing around with free monads, and found that things work somewhat well in the [non-recursive church-encoded form](https://hackage.haskell.org/package/free-5.1/docs/Control-Monad-Free-Church.html), due to how dhall natively supports Rank-N types so well.  Let me know if this is something you'd find useful to incorporate :)  Also let me know if there are any stylistic things I can change to to make it more in line with the rest of the library.  I've tried my best to adhere to the argument order (passing in types vs. passing in instances) I've observed in the library.

I've tested for compatibility with language spec 5.0 (and Haskell package *dhall-1.20*)